### PR TITLE
Add basic route heading tests

### DIFF
--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import About from './About';
+
+test('renders heading', () => {
+  render(<About loading={true} error={false} shops={[]} />);
+  const heading = screen.getByRole('heading', { name: /about us/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/routes/Brands.test.tsx
+++ b/src/routes/Brands.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Brands from './Brands';
+
+test('renders heading', () => {
+  render(<Brands loading={true} error={false} shops={[]} />);
+  const heading = screen.getByRole('heading', { name: /our brands/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/routes/Contact.test.tsx
+++ b/src/routes/Contact.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Contact from './Contact';
+
+test('renders heading', () => {
+  render(<Contact loading={true} error={false} shops={[]} />);
+  const heading = screen.getByRole('heading', { name: /need support\?/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Home from './Home';
+
+test('renders heading', () => {
+  render(
+    <Home loading={true} error={false} shops={[]} articles={[]} />
+  );
+  const heading = screen.getByRole('heading', { name: /latest news/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/routes/News.test.tsx
+++ b/src/routes/News.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import News from './News';
+
+test('renders heading', () => {
+  render(<News loading={true} error={false} articles={[]} />);
+  const heading = screen.getByRole('heading', { name: /latest news/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/routes/Responsibility.test.tsx
+++ b/src/routes/Responsibility.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Responsibility from './Responsibility';
+
+test('renders heading', () => {
+  render(<Responsibility />);
+  const heading = screen.getByRole('heading', { name: /our commitment/i });
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add tests for Home, About, Brands, News, Responsibility, and Contact routes

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684dd5143ae4832684a628820801b19e