### PR TITLE
Add security attributes to outbound buttons

### DIFF
--- a/src/components/Articles.test.tsx
+++ b/src/components/Articles.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Articles from './Articles';
+
+test('article links have security attributes', () => {
+  const articles = [
+    {
+      id: '1',
+      title: 'Test',
+      onlineStoreUrl: 'https://example.com',
+      publishedAt: '2022-01-01T00:00:00Z',
+    },
+  ];
+  render(<Articles loading={false} error={false} articles={articles} />);
+  const link = screen.getByRole('button', { name: /read more/i });
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+

--- a/src/components/Articles.tsx
+++ b/src/components/Articles.tsx
@@ -49,7 +49,15 @@ function Articles(props: ArticleProps) {
             <Card.Body>
               <Card.Title>{article.title}</Card.Title>
               <Card.Text dangerouslySetInnerHTML={{ __html: article.excerptHtml || '' }} />
-              <Button variant="more" as="a" href={article.onlineStoreUrl}>Read more</Button>
+              <Button
+                variant="more"
+                as="a"
+                href={article.onlineStoreUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Read more
+              </Button>
             </Card.Body>
             <Card.Footer className="text-muted">{new Date(article.publishedAt).toLocaleDateString(undefined, {
               day: 'numeric',

--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -8,3 +8,10 @@ test('renders heading', () => {
   const heading = screen.getByRole('heading', { name: /about us/i });
   expect(heading).toBeInTheDocument();
 });
+
+test('team links open in new tab', () => {
+  render(<About loading={false} error={false} shops={[]} />);
+  const [link] = screen.getAllByRole('button', { name: /linkedin/i });
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -111,7 +111,15 @@ function About(props: ShopProps) {
                 <Card.Body>
                   <Card.Title>{member.firstName} {member.lastName}</Card.Title>
                   <Card.Text>{member.job}</Card.Text>
-                  <Button variant="more" as="a" href={member.linkedInUrl}>LinkedIn</Button>
+                  <Button
+                    variant="more"
+                    as="a"
+                    href={member.linkedInUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    LinkedIn
+                  </Button>
                 </Card.Body>
               </Card>
             </Col>

--- a/src/routes/Brands.test.tsx
+++ b/src/routes/Brands.test.tsx
@@ -8,3 +8,19 @@ test('renders heading', () => {
   const heading = screen.getByRole('heading', { name: /our brands/i });
   expect(heading).toBeInTheDocument();
 });
+
+test('external links have security attributes', () => {
+  const shops = [
+    {
+      id: '1',
+      name: 'Test',
+      shipsToCountries: [],
+      primaryDomain: { url: 'https://example.com' },
+      brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } }
+    }
+  ];
+  render(<Brands loading={false} error={false} shops={shops} />);
+  const link = screen.getByRole('button', { name: /learn more/i });
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});

--- a/src/routes/Brands.tsx
+++ b/src/routes/Brands.tsx
@@ -70,7 +70,15 @@ function Brands(props: ShopProps) {
               </Col>
               <Col className="mb-3" xs={12} md={10}>
                 <p className="lead">{shop.brand?.shortDescription}</p>
-                <Button variant="more" as="a" href={shop.primaryDomain.url}>Learn more</Button>
+                <Button
+                  variant="more"
+                  as="a"
+                  href={shop.primaryDomain.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more
+                </Button>
               </Col>
             </Row>
           </Container>

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -10,3 +10,21 @@ test('renders heading', () => {
   const heading = screen.getByRole('heading', { name: /latest news/i });
   expect(heading).toBeInTheDocument();
 });
+
+test('brand link has security attributes', () => {
+  const shops = [
+    {
+      id: '1',
+      name: 'Test',
+      shipsToCountries: [],
+      primaryDomain: { url: 'https://example.com' },
+      brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } }
+    }
+  ];
+  render(
+    <Home loading={false} error={false} shops={shops} articles={[]} />
+  );
+  const link = screen.getByRole('button', { name: /learn more/i });
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -50,9 +50,19 @@ function Home(props: HomeProps) {
               <Container>
                 <h1 className="display-1">{shop.name}</h1>
                 <p className="lead">{shop.brand?.slogan}</p>
-                <Button variant="more" size="lg" as="a" href={shop.primaryDomain.url} style={{
-                  '--bs-btn-color': shop.brand?.colors.primary[0].foreground
-                } as React.CSSProperties}>Learn more</Button>
+                <Button
+                  variant="more"
+                  size="lg"
+                  as="a"
+                  href={shop.primaryDomain.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    '--bs-btn-color': shop.brand?.colors.primary[0].foreground
+                  } as React.CSSProperties}
+                >
+                  Learn more
+                </Button>
               </Container>
             </Carousel.Caption>
           </Carousel.Item>


### PR DESCRIPTION
## Summary
- open brand and article links in new tabs securely
- test that all outbound buttons include target and rel

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684dfb118f088326b9b3624bffab97fc