### PR TITLE
Expand route tests

### DIFF
--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -3,15 +3,24 @@ import { render, screen } from '@testing-library/react';
 
 import About from './About';
 
+const urls = [
+  'http://linkedin.com/in/kristianmatthewskennington',
+  'https://linkedin.com/in/paul-matthews-kennington-201007a6',
+];
+
 test('renders heading', () => {
   render(<About loading={true} error={false} shops={[]} />);
   const heading = screen.getByRole('heading', { name: /about us/i });
   expect(heading).toBeInTheDocument();
 });
 
-test('team links open in new tab', () => {
+test('renders team links', () => {
   render(<About loading={false} error={false} shops={[]} />);
-  const [link] = screen.getAllByRole('button', { name: /linkedin/i });
-  expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  const links = screen.getAllByRole('button', { name: /linkedin/i });
+  expect(links).toHaveLength(2);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', urls[i]);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/routes/Brands.test.tsx
+++ b/src/routes/Brands.test.tsx
@@ -3,24 +3,39 @@ import { render, screen } from '@testing-library/react';
 
 import Brands from './Brands';
 
+const shops = Array.from({ length: 4 }, (_, i) => ({
+  id: String(i + 1),
+  name: `Test ${i + 1}`,
+  shipsToCountries: [],
+  primaryDomain: { url: `https://example${i + 1}.com` },
+  brand: {
+    shortDescription: `Description ${i + 1}`,
+    coverImage: { image: { carouselUrl: `cover${i + 1}.jpg` } },
+    logo: {
+      image: {
+        logoUrl: `logo${i + 1}.png`,
+        altText: `Logo ${i + 1}`,
+        width: 1,
+        height: 1,
+      },
+    },
+    colors: { primary: [{ background: '#fff', foreground: '#000' }] },
+  },
+}));
+
 test('renders heading', () => {
   render(<Brands loading={true} error={false} shops={[]} />);
   const heading = screen.getByRole('heading', { name: /our brands/i });
   expect(heading).toBeInTheDocument();
 });
 
-test('external links have security attributes', () => {
-  const shops = [
-    {
-      id: '1',
-      name: 'Test',
-      shipsToCountries: [],
-      primaryDomain: { url: 'https://example.com' },
-      brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } }
-    }
-  ];
+test('renders brand cards with correct links', () => {
   render(<Brands loading={false} error={false} shops={shops} />);
-  const link = screen.getByRole('button', { name: /learn more/i });
-  expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  const links = screen.getAllByRole('button', { name: /learn more/i });
+  expect(links).toHaveLength(4);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/routes/Contact.test.tsx
+++ b/src/routes/Contact.test.tsx
@@ -3,8 +3,28 @@ import { render, screen } from '@testing-library/react';
 
 import Contact from './Contact';
 
+const shops = Array.from({ length: 2 }, (_, i) => ({
+  id: String(i + 1),
+  name: `Shop ${i + 1}`,
+  shipsToCountries: [],
+  primaryDomain: { url: `https://shop${i + 1}.com` },
+  brand: {
+    logo: { image: { logoUrl: `logo${i + 1}.png`, altText: `Logo ${i + 1}`, width: 1, height: 1 } },
+    colors: { primary: [{ background: '#fff', foreground: '#000' }] },
+  },
+}));
+
 test('renders heading', () => {
   render(<Contact loading={true} error={false} shops={[]} />);
   const heading = screen.getByRole('heading', { name: /need support\?/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('renders brand links', () => {
+  render(<Contact loading={false} error={false} shops={shops} />);
+  const links = screen.getAllByRole('link');
+  expect(links).toHaveLength(2);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+  });
 });

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -3,6 +3,14 @@ import { render, screen } from '@testing-library/react';
 
 import Home from './Home';
 
+const shops = Array.from({ length: 2 }, (_, i) => ({
+  id: String(i + 1),
+  name: `Shop ${i + 1}`,
+  shipsToCountries: [],
+  primaryDomain: { url: `https://shop${i + 1}.com` },
+  brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } },
+}));
+
 test('renders heading', () => {
   render(
     <Home loading={true} error={false} shops={[]} articles={[]} />
@@ -11,20 +19,13 @@ test('renders heading', () => {
   expect(heading).toBeInTheDocument();
 });
 
-test('brand link has security attributes', () => {
-  const shops = [
-    {
-      id: '1',
-      name: 'Test',
-      shipsToCountries: [],
-      primaryDomain: { url: 'https://example.com' },
-      brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } }
-    }
-  ];
-  render(
-    <Home loading={false} error={false} shops={shops} articles={[]} />
-  );
-  const link = screen.getByRole('button', { name: /learn more/i });
-  expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+test('renders brand links with correct hrefs', () => {
+  render(<Home loading={false} error={false} shops={shops} articles={[]} />);
+  const links = screen.getAllByRole('button', { name: /learn more/i });
+  expect(links).toHaveLength(2);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/routes/News.test.tsx
+++ b/src/routes/News.test.tsx
@@ -3,8 +3,26 @@ import { render, screen } from '@testing-library/react';
 
 import News from './News';
 
+const articles = Array.from({ length: 2 }, (_, i) => ({
+  id: String(i + 1),
+  title: `Article ${i + 1}`,
+  onlineStoreUrl: `https://example.com/article${i + 1}`,
+  publishedAt: '2022-01-01T00:00:00Z',
+}));
+
 test('renders heading', () => {
   render(<News loading={true} error={false} articles={[]} />);
   const heading = screen.getByRole('heading', { name: /latest news/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('renders article links', () => {
+  render(<News loading={false} error={false} articles={articles} />);
+  const links = screen.getAllByRole('button', { name: /read more/i });
+  expect(links).toHaveLength(2);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', articles[i].onlineStoreUrl);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/routes/PrivacyPolicy.test.tsx
+++ b/src/routes/PrivacyPolicy.test.tsx
@@ -11,3 +11,9 @@ test('renders heading', () => {
   });
   expect(heading).toBeInTheDocument();
 });
+
+test('shows introduction section', () => {
+  render(<PrivacyPolicy />);
+  const section = screen.getByRole('heading', { name: /introduction and scope/i });
+  expect(section).toBeInTheDocument();
+});

--- a/src/routes/Responsibility.test.tsx
+++ b/src/routes/Responsibility.test.tsx
@@ -8,3 +8,9 @@ test('renders heading', () => {
   const heading = screen.getByRole('heading', { name: /our commitment/i });
   expect(heading).toBeInTheDocument();
 });
+
+test('shows commitment text', () => {
+  render(<Responsibility />);
+  const paragraph = screen.getByText(/is committed to making the world/i);
+  expect(paragraph).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- cover more Brands page interactions
- test more UI elements for all routes

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684dfec4cc948326acd89b407e89e7fa