### PR TITLE
Add Links route with cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const News = React.lazy(() => import('./routes/News'));
 const Responsibility = React.lazy(() => import('./routes/Responsibility'));
 const Contact = React.lazy(() => import('./routes/Contact'));
 const PrivacyPolicy = React.lazy(() => import('./routes/PrivacyPolicy'));
+const Links = React.lazy(() => import('./routes/Links'));
 
 interface StorefrontData {
   shop: Shop
@@ -230,6 +231,7 @@ function App() {
           <Route path="/news" element={<News loading={loading} error={error} articles={articles} />} />
           <Route path="/responsibility" element={<Responsibility />} />
           <Route path="/contact" element={<Contact loading={loading} error={error} shops={shops} />} />
+          <Route path="/links" element={<Links />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         </Routes>
       </React.Suspense>

--- a/src/routes/Links.scss
+++ b/src/routes/Links.scss
@@ -1,0 +1,12 @@
+.links {
+  margin-top: 1rem;
+}
+
+.links .card {
+  margin-bottom: 1rem;
+}
+
+.links .card-img-top {
+  width: 4rem;
+  margin: 0.5rem auto;
+}

--- a/src/routes/Links.test.tsx
+++ b/src/routes/Links.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Links from './Links';
+
+const hrefs = [
+  'https://m-k.enterprises',
+  'https://bearbelts.com',
+  'https://pocketbears.com',
+  'https://sizzlesoak.com',
+];
+
+test('renders heading', () => {
+  render(<Links />);
+  const heading = screen.getByRole('heading', { name: /useful links/i });
+  expect(heading).toBeInTheDocument();
+});
+
+test('renders four cards with correct links', () => {
+  render(<Links />);
+  const links = screen.getAllByRole('button', { name: /visit/i });
+  expect(links).toHaveLength(4);
+  links.forEach((link, i) => {
+    expect(link).toHaveAttribute('href', hrefs[i]);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/routes/Links.tsx
+++ b/src/routes/Links.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Button, Card, Col, Container, Row } from 'react-bootstrap';
+import { Block } from '@smolpack/react-bootstrap-extensions';
+import logo from '../logo.svg';
+import './Links.scss';
+
+/**
+ * External links page.
+ *
+ * @returns React element containing corporate links.
+ */
+function Links() {
+  const items = [
+    { name: 'M-K Enterprises', tagline: 'Corporate site', href: 'https://m-k.enterprises' },
+    { name: 'Bear Belts', tagline: 'Belts for every bear', href: 'https://bearbelts.com' },
+    { name: 'Pocket Bears Apparel', tagline: 'Pocket-sized style', href: 'https://pocketbears.com' },
+    { name: 'Sizzle Soak', tagline: 'Add flavour fast', href: 'https://sizzlesoak.com' },
+  ];
+
+  return (
+    <>
+      <Block className="text-bg-primary">
+        <Container>
+          <Block.Title>Useful Links</Block.Title>
+        </Container>
+      </Block>
+      <Block>
+        <Container className="links">
+          <Row>
+            {items.map(link => (
+              <Col key={link.href} xs={12} md={6} className="d-flex">
+                <Card className="flex-fill text-center">
+                  <Card.Img variant="top" src={logo} alt="logo" width={64} height={64} />
+                  <Card.Body>
+                    <Card.Title>{link.name}</Card.Title>
+                    <Card.Text>{link.tagline}</Card.Text>
+                    <Button
+                      variant="more"
+                      as="a"
+                      href={link.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Visit
+                    </Button>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </Container>
+      </Block>
+    </>
+  );
+}
+
+export default Links;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,3 +5,4 @@ export { default as News } from './News';
 export { default as Responsibility } from './Responsibility';
 export { default as Contact } from './Contact';
 export { default as PrivacyPolicy } from './PrivacyPolicy';
+export { default as Links } from './Links';


### PR DESCRIPTION
## Summary
- add a new Links page with 4 cards
- style the links layout
- test the new route
- export Links route and add router entry

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684e10bcf2e08326922cfcaacb02448b