### PR TITLE
Fix TypeScript build errors and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://m-k.enterprises",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@apollo/client": "^3.7.3",
     "@smolpack/bootstrap-extensions": "^1.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,10 +27,10 @@ interface StorefrontData {
   }
 }
 
-interface Shop {
+export interface Shop {
   id: string
   name: string
-  shipsToCountries: [string]
+  shipsToCountries: string[]
   primaryDomain: {
     url: string
   }

--- a/src/clients.test.ts
+++ b/src/clients.test.ts
@@ -24,3 +24,5 @@ test('exports clients when tokens present', () => {
   expect(clients.bearBelts).toBeTruthy();
 });
 
+export {}
+

--- a/src/routes/Brands.test.tsx
+++ b/src/routes/Brands.test.tsx
@@ -2,17 +2,19 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Brands from './Brands';
+import { Shop } from '../App';
 
-const shops = Array.from({ length: 4 }, (_, i) => ({
+const shops: Shop[] = Array.from({ length: 4 }, (_, i) => ({
   id: String(i + 1),
   name: `Test ${i + 1}`,
   shipsToCountries: [],
   primaryDomain: { url: `https://example${i + 1}.com` },
   brand: {
     shortDescription: `Description ${i + 1}`,
-    coverImage: { image: { carouselUrl: `cover${i + 1}.jpg` } },
+    coverImage: { image: { url: '', carouselUrl: `cover${i + 1}.jpg` } },
     logo: {
       image: {
+        url: '',
         logoUrl: `logo${i + 1}.png`,
         altText: `Logo ${i + 1}`,
         width: 1,

--- a/src/routes/Contact.test.tsx
+++ b/src/routes/Contact.test.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Contact from './Contact';
+import { Shop } from '../App';
 
-const shops = Array.from({ length: 2 }, (_, i) => ({
+const shops: Shop[] = Array.from({ length: 2 }, (_, i) => ({
   id: String(i + 1),
   name: `Shop ${i + 1}`,
   shipsToCountries: [],
   primaryDomain: { url: `https://shop${i + 1}.com` },
   brand: {
-    logo: { image: { logoUrl: `logo${i + 1}.png`, altText: `Logo ${i + 1}`, width: 1, height: 1 } },
+    logo: { image: { url: '', logoUrl: `logo${i + 1}.png`, altText: `Logo ${i + 1}`, width: 1, height: 1 } },
     colors: { primary: [{ background: '#fff', foreground: '#000' }] },
   },
 }));

--- a/src/routes/Home.test.tsx
+++ b/src/routes/Home.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Home from './Home';
+import { Shop } from '../App';
 
-const shops = Array.from({ length: 2 }, (_, i) => ({
+const shops: Shop[] = Array.from({ length: 2 }, (_, i) => ({
   id: String(i + 1),
   name: `Shop ${i + 1}`,
   shipsToCountries: [],


### PR DESCRIPTION
## Summary
- export `Shop` type and fix `shipsToCountries` typing
- add missing image URLs in tests and use `Shop` type
- make `clients.test.ts` a module
- pin package manager to Yarn v1

## Testing
- `yarn build`
- `CI=true yarn test --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_684f240506bc8326b9a64c363a232be4