### PR TITLE
Add alt text for About page image

### DIFF
--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -24,3 +24,9 @@ test('renders team links', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });
+
+test('renders about image with alt', () => {
+  render(<About loading={false} error={false} shops={[]} />);
+  const image = screen.getByAltText(/Bear Belts launch event/i);
+  expect(image).toBeInTheDocument();
+});

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -63,7 +63,7 @@ function About(props: ShopProps) {
           <Row className="align-items-center">
             <Col>
               <Figure>
-                <Figure.Image src={about} fluid />
+                <Figure.Image src={about} alt="Bear Belts launch event" fluid />
                 <Figure.Caption className="text-center">Bear Belts' first event in Edinburgh.</Figure.Caption>
               </Figure>
             </Col>


### PR DESCRIPTION
## Summary
- add alt text to About page image for accessibility
- test alt attribute rendering

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684fd5dcdcd08326a831eaec6a34544e