### PR TITLE
Add dynamic Links route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,7 +210,7 @@ function App() {
           <Route path="/news" element={<News loading={loading} error={error} articles={articles} />} />
           <Route path="/responsibility" element={<Responsibility />} />
           <Route path="/contact" element={<Contact loading={loading} error={error} shops={shops} />} />
-          <Route path="/links" element={<Links />} />
+          <Route path="/links" element={<Links loading={loading} error={error} shops={shops} />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         </Routes>
       </React.Suspense>

--- a/src/routes/LinkCard.tsx
+++ b/src/routes/LinkCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button, Card, Col } from 'react-bootstrap';
+import logo from '../logo.svg';
+
+interface LinkCardProps {
+  name: string;
+  tagline?: string;
+  href: string;
+}
+
+/**
+ * Renders a single external link card.
+ *
+ * @param props - Link details for the card.
+ * @returns JSX for a link card.
+ */
+export default function LinkCard(props: LinkCardProps) {
+  return (
+    <Col xs={12} md={6} className="d-flex">
+      <Card className="flex-fill text-center">
+        <Card.Img variant="top" src={logo} alt="logo" width={64} height={64} />
+        <Card.Body>
+          <Card.Title>{props.name}</Card.Title>
+          <Card.Text>{props.tagline}</Card.Text>
+          <Button
+            variant="more"
+            as="a"
+            href={props.href}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Visit
+          </Button>
+        </Card.Body>
+      </Card>
+    </Col>
+  );
+}

--- a/src/routes/Links.test.tsx
+++ b/src/routes/Links.test.tsx
@@ -2,27 +2,28 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Links from './Links';
+import { Shop } from '../App';
 
-const hrefs = [
-  'https://m-k.enterprises',
-  'https://bearbelts.store',
-  'https://pocketbearsapparel.store',
-  'https://mythicalmoods.store',
-  'https://aura-and-essence.store',
-];
+const shops: Shop[] = Array.from({ length: 3 }, (_, i) => ({
+  id: String(i + 1),
+  name: `Shop ${i + 1}`,
+  shipsToCountries: [],
+  primaryDomain: { url: `https://shop${i + 1}.com` },
+  brand: { slogan: `Tagline ${i + 1}` }
+}));
 
 test('renders heading', () => {
-  render(<Links />);
+  render(<Links loading={false} error={false} shops={shops} />);
   const heading = screen.getByRole('heading', { name: /useful links/i });
   expect(heading).toBeInTheDocument();
 });
 
-test('renders five cards with correct links', () => {
-  render(<Links />);
+test('renders cards with correct links', () => {
+  render(<Links loading={false} error={false} shops={shops} />);
   const links = screen.getAllByRole('button', { name: /visit/i });
-  expect(links).toHaveLength(5);
+  expect(links).toHaveLength(shops.length);
   links.forEach((link, i) => {
-    expect(link).toHaveAttribute('href', hrefs[i]);
+    expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/routes/Links.tsx
+++ b/src/routes/Links.tsx
@@ -1,23 +1,26 @@
 import React from 'react';
-import { Button, Card, Col, Container, Row } from 'react-bootstrap';
+import { Container, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
-import logo from '../logo.svg';
+
+import { ShopProps } from '../App';
+import LinkCard from './LinkCard';
 import './Links.scss';
+
+interface LinksProps extends ShopProps {}
 
 /**
  * External links page.
  *
+ * @param props - Shop data with loading state.
  * @returns React element containing corporate links.
  */
-function Links() {
-  const items = [
-    { name: 'M-K Enterprises', tagline: 'Corporate site', href: 'https://m-k.enterprises' },
-    { name: 'Bear Belts', tagline: 'Belts for every bear', href: 'https://bearbelts.store' },
-    { name: 'Pocket Bears Apparel', tagline: 'Pocket-sized style', href: 'https://pocketbearsapparel.store' },
-    // { name: 'Sizzle & Soak', tagline: 'Add flavour fast', href: 'https://sizzleandsoak.store' },
-    { name: 'Mythical Moods', tagline: 'Enchanting scents', href: 'https://mythicalmoods.store' },
-    { name: 'Aura & Essence', tagline: 'Holistic aromas', href: 'https://aura-and-essence.store' },
-  ];
+
+function Links(props: LinksProps) {
+  const items = props.shops.map(shop => ({
+    name: shop.name,
+    tagline: shop.brand?.slogan,
+    href: shop.primaryDomain.url,
+  }));
 
   return (
     <>
@@ -30,24 +33,7 @@ function Links() {
         <Container className="links">
           <Row>
             {items.map(link => (
-              <Col key={link.href} xs={12} md={6} className="d-flex">
-                <Card className="flex-fill text-center">
-                  <Card.Img variant="top" src={logo} alt="logo" width={64} height={64} />
-                  <Card.Body>
-                    <Card.Title>{link.name}</Card.Title>
-                    <Card.Text>{link.tagline}</Card.Text>
-                    <Button
-                      variant="more"
-                      as="a"
-                      href={link.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Visit
-                    </Button>
-                  </Card.Body>
-                </Card>
-              </Col>
+              <LinkCard key={link.href} name={link.name} tagline={link.tagline} href={link.href} />
             ))}
           </Row>
         </Container>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,3 +6,4 @@ export { default as Responsibility } from './Responsibility';
 export { default as Contact } from './Contact';
 export { default as PrivacyPolicy } from './PrivacyPolicy';
 export { default as Links } from './Links';
+export { default as LinkCard } from './LinkCard';


### PR DESCRIPTION
## Summary
- pass shop query props to Links route
- build Links route from shop data
- add LinkCard template component
- export LinkCard from routes index
- update Links tests

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685042bc2f3883268ea30190a9fd67f7