### PR TITLE
Add shop colors to Links test

### DIFF
--- a/src/routes/Links.test.tsx
+++ b/src/routes/Links.test.tsx
@@ -9,7 +9,7 @@ const shops: Shop[] = Array.from({ length: 3 }, (_, i) => ({
   name: `Shop ${i + 1}`,
   shipsToCountries: [],
   primaryDomain: { url: `https://shop${i + 1}.com` },
-  brand: { slogan: `Tagline ${i + 1}` }
+  brand: { slogan: `Tagline ${i + 1}`, colors: { primary: [{}] } }
 }));
 
 test('renders heading', () => {


### PR DESCRIPTION
## Summary
- add minimal colors to mocked brand objects in Links route tests

## Testing
- `yarn test --coverage --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685131333fac8326a01149722d9d09fc