### PR TITLE
Update README to Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,49 @@
-# Getting Started with Create React App
+# Getting Started with Next.js
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project uses [Next.js](https://nextjs.org/) for server-side rendered React.
 
 ## Setup
 
 1. Copy `.env.example` to `.env` and fill in your Shopify tokens.
 2. Install dependencies with `yarn install` or `npm install`.
-3. Start the dev server with `yarn start`.
-
-### Required environment variables
+3. Start the dev server with `next dev`.
 
 ```
-REACT_APP_SHOPIFY_TOKEN_BEAR_BELTS=<token>
-REACT_APP_SHOPIFY_TOKEN_POCKET_BEARS_APPAREL=<token>
-REACT_APP_SHOPIFY_TOKEN_MYTHICAL_MOODS=<token>
-REACT_APP_SHOPIFY_TOKEN_AURA_ESSENCE=<token>
-# REACT_APP_SHOPIFY_TOKEN_SIZZLE_SOAK=<token> # optional, currently disabled
+NEXT_PUBLIC_SHOPIFY_TOKEN_BEAR_BELTS=<token>
+NEXT_PUBLIC_SHOPIFY_TOKEN_POCKET_BEARS_APPAREL=<token>
+NEXT_PUBLIC_SHOPIFY_TOKEN_MYTHICAL_MOODS=<token>
+NEXT_PUBLIC_SHOPIFY_TOKEN_AURA_ESSENCE=<token>
+# NEXT_PUBLIC_SHOPIFY_TOKEN_SIZZLE_SOAK=<token> # optional, currently disabled
 ```
 
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `yarn start`
+### `next dev`
 
-Runs the app in the development mode.\
+Runs the app in development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-The page will reload if you make edits.\
+The page reloads on edits.\
 You will also see any lint errors in the console.
 
-### `yarn test`
+### `next test`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Launches the test runner in interactive watch mode.
 
 ### `yarn lint`
 
 Runs ESLint over all `.ts` and `.tsx` files in `src/`.
 
-### `yarn build`
+### `next build`
 
 Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Next.js optimizes the output for performance.
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
 
 ## Learn More
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+You can learn more in the [Next.js documentation](https://nextjs.org/docs).
 
 To learn React, check out the [React documentation](https://reactjs.org/).


### PR DESCRIPTION
## Summary
- update introduction for Next.js
- document NEXT_PUBLIC_ env vars
- update script instructions to use `next` commands
- remove CRA eject docs

## Testing
- `yarn test --coverage --watchAll=false` *(fails: Unable to find heading in Links.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685273d4651c832695275aaeb3f5c3bf