### PR TITLE
Add global layout and tests

### DIFF
--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import RootLayout from './layout';
+
+const Child = () => <div>Child</div>;
+
+test('renders brand link', () => {
+  render(
+    <RootLayout>
+      <Child />
+    </RootLayout>
+  );
+  const link = screen.getByRole('link', { name: /enterprises/i });
+  expect(link).toBeInTheDocument();
+});
+
+test('renders children content', () => {
+  render(
+    <RootLayout>
+      <Child />
+    </RootLayout>
+  );
+  expect(screen.getByText('Child')).toBeInTheDocument();
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,13 +3,25 @@ import React from 'react';
 import Link from 'next/link';
 import { Container, Image as Img, Nav, Navbar } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
+
 import logo from '../logo.svg';
+
+import 'bootstrap/dist/css/bootstrap.min.css';
 import '../index.scss';
+import '../App.scss';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
+/**
+ * Root layout wrapping every page.
+ *
+ * Imports Bootstrap and custom SCSS so styles and fonts apply globally.
+ *
+ * @param props - Layout content.
+ * @returns Page wrapper element.
+ */
 export default function RootLayout({ children }: LayoutProps) {
   const now = new Date();
 


### PR DESCRIPTION
## Summary
- import Bootstrap and SCSS in the app router layout
- document the layout component
- test the layout renders brand link and children

## Testing
- `yarn test`
- `yarn lint` *(fails: all files are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_685453a1bee083268993484ba1377990