### PR TITLE
Fix layout test root container

### DIFF
--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -5,21 +5,27 @@ import RootLayout from './layout';
 
 const Child = () => <div>Child</div>;
 
+beforeEach(() => {
+  document.documentElement.innerHTML = '<head></head><body></body>';
+});
+
 test('renders brand link', () => {
-  render(
+  const { getByRole } = render(
     <RootLayout>
       <Child />
-    </RootLayout>
+    </RootLayout>,
+    { container: document.documentElement, baseElement: document.documentElement }
   );
-  const link = screen.getByRole('link', { name: /enterprises/i });
+  const link = getByRole('link', { name: /enterprises/i });
   expect(link).toBeInTheDocument();
 });
 
 test('renders children content', () => {
-  render(
+  const { getByText } = render(
     <RootLayout>
       <Child />
-    </RootLayout>
+    </RootLayout>,
+    { container: document.documentElement, baseElement: document.documentElement }
   );
-  expect(screen.getByText('Child')).toBeInTheDocument();
+  expect(getByText('Child')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- mount `<RootLayout>` directly on `document.documentElement`
- clear document root before each test
- query using render helpers instead of `screen`

## Testing
- `yarn lint`
- `npx tsc --noEmit`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6854963edae48326967c1fc710c74583