### PR TITLE
Define page prop interfaces

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -15,15 +15,16 @@ import about from './about.jpg';
  * @param props - Shop data with loading state.
  * @returns JSX for the about route.
  */
-export default function Page(props: any) {
-  const shops = props?.shops ?? [];
-  const loading = props?.loading ?? false;
-  const error = props?.error ?? false;
+export default function Page({
+  shops = [],
+  loading = false,
+  error = false,
+}: ShopProps) {
   const shipsToCountriesMin = intersection(
-    ...shops.map((shop: any) => shop.shipsToCountries)
+    ...shops.map(shop => shop.shipsToCountries)
   ).length;
   const shipsToCountriesMax = union(
-    ...shops.map((shop: any) => shop.shipsToCountries)
+    ...shops.map(shop => shop.shipsToCountries)
   ).length;
 
   const team = [

--- a/src/app/brands/page.tsx
+++ b/src/app/brands/page.tsx
@@ -11,10 +11,11 @@ import { ShopProps } from '../../types';
  * @param props - Shop data for all brands.
  * @returns JSX for the brands route.
  */
-export default function Brands(props: any) {
-  const shops = props?.shops ?? [];
-  const loading = props?.loading ?? false;
-  const error = props?.error ?? false;
+export default function Brands({
+  shops = [],
+  loading = false,
+  error = false,
+}: ShopProps) {
   return (
     <>
       <Block className="text-bg-primary">
@@ -22,7 +23,7 @@ export default function Brands(props: any) {
           <Block.Title>Our Brands</Block.Title>
         </Container>
       </Block>
-      {loading || error ? Array.from({ length: 2 }).map((_: any, index: number) => (
+      {loading || error ? Array.from({ length: 2 }).map((_, index: number) => (
         <Block key={index}>
           <Container className="border-bottom border-4">
             <Row className="justify-content-center mb-3">
@@ -57,7 +58,7 @@ export default function Brands(props: any) {
             </Row>
           </Container>
         </Block>
-      )) : shops.map((shop: any, index: number) => (
+      )) : shops.map((shop, index: number) => (
         <Block key={shop.id}>
           <Container className="border-bottom border-4" style={{
             '--bs-border-color': shop.brand?.colors.primary[0].background

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -10,10 +10,11 @@ import { ShopProps } from '../../types';
  * @param props - Shop data with loading state.
  * @returns JSX for the contact route.
  */
-export default function Contact(props: any) {
-  const shops = props?.shops ?? [];
-  const loading = props?.loading ?? false;
-  const error = props?.error ?? false;
+export default function Contact({
+  shops = [],
+  loading = false,
+  error = false,
+}: ShopProps) {
   return (
     <>
       <Block className="text-bg-primary">
@@ -25,7 +26,7 @@ export default function Contact(props: any) {
         <Container>
           <p className="lead">Our in-house customer service team is here to help. Please connect with us by visiting one of our brands below.</p>
           <Row className="align-items-center justify-content-evenly text-center">
-            {loading || error ? Array.from({ length: 2 }).map((_: any, i: number) => (
+            {loading || error ? Array.from({ length: 2 }).map((_, i: number) => (
               <Col key={i} xs={10} md={5} xl={4}>
                 <Ratio aspectRatio="16x9">
                   <Placeholder className="img-fluid" animation="glow">
@@ -33,7 +34,7 @@ export default function Contact(props: any) {
                   </Placeholder>
                 </Ratio>
               </Col>
-            )) : shops.map((shop: any) => (
+            )) : shops.map(shop => (
               <Col key={shop.id} xs={10} md={5} xl={4}>
                 <a href={shop.primaryDomain.url}>
                   <Image src={shop.brand?.logo?.image?.logoUrl} alt={shop.brand?.logo?.image?.altText} width={shop.brand?.logo?.image?.width} height={shop.brand?.logo?.image?.height} fluid />

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -15,8 +15,7 @@ interface LinksProps extends ShopProps {}
  * @returns React element containing corporate links.
  */
 
-export default function Links(props: any) {
-  const shops = props?.shops ?? [];
+export default function Links({ shops = [] }: LinksProps) {
   const items = shops;
 
   return (
@@ -25,7 +24,7 @@ export default function Links(props: any) {
         <Container className="links">
           <Block.Title>Useful Links</Block.Title>
           <Row className="g-3">
-            {items.map((shop: any) => (
+            {items.map(shop => (
               <Col key={shop.id} xs={12} md={6} className="d-flex">
                 <LinkCard shop={shop} />
               </Col>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -11,10 +11,11 @@ import { ArticleProps } from '../../types';
  * @param props - Article data with loading state.
  * @returns JSX for the news route.
  */
-export default function News(props: any) {
-  const loading = props?.loading ?? false;
-  const error = props?.error ?? false;
-  const articles = props?.articles ?? [];
+export default function News({
+  loading = false,
+  error = false,
+  articles = [],
+}: ArticleProps) {
   return (
     <>
       <Block className="text-bg-primary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,7 @@ import { Button, Carousel, Container, Placeholder, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { random } from 'lodash';
 import { Articles } from '../components';
-import { ArticleProps, ShopProps } from '../types';
-
-interface HomeProps extends ShopProps, ArticleProps {}
+import { HomeProps } from '../types';
 
 /**
  * Home page showing brand highlights and latest news.
@@ -14,11 +12,12 @@ interface HomeProps extends ShopProps, ArticleProps {}
  * @param props - Shop and article data with loading states.
  * @returns JSX for the home route.
  */
-export default function Home(props: any) {
-  const shops = props?.shops ?? [];
-  const articles = props?.articles ?? [];
-  const loading = props?.loading ?? false;
-  const error = props?.error ?? false;
+export default function Home({
+  shops = [],
+  articles = [],
+  loading = false,
+  error = false,
+}: HomeProps) {
   return (
     <>
       <Carousel>
@@ -47,7 +46,7 @@ export default function Home(props: any) {
               </Container>
             </Carousel.Caption>
           </Carousel.Item>
-        ) : shops.map((shop: any) => (
+        ) : shops.map(shop => (
           <Carousel.Item key={shop.id} className="carousel-item-large" style={{
             backgroundColor: shop.brand?.colors.primary[0].background
           }}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,5 @@ export interface ShopProps extends QueryProps {
 export interface ArticleProps extends QueryProps {
   articles: Article[];
 }
+
+export interface HomeProps extends ShopProps, ArticleProps {}


### PR DESCRIPTION
## Summary
- type page props instead of using `any`
- add `HomeProps` shared interface
- destructure props with defaults

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68582e98d750832684a47ca1d0a6e80e