### PR TITLE
Fix URL typing in components

### DIFF
--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -20,6 +20,7 @@ test('renders team links', () => {
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', urls[i]);
+    expect(typeof link.getAttribute('href')).toBe('string');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,6 +6,7 @@ import { intersection, union } from 'lodash';
 import Gravatar from 'react-gravatar';
 
 import { ShopProps } from '../../types';
+import { ensureString } from '../../utils';
 // @ts-expect-error Image imported as URL
 import about from './about.jpg';
 
@@ -131,7 +132,7 @@ export default function Page({
                   <Button
                     variant="more"
                     as="a"
-                    href={member.linkedInUrl}
+                    href={ensureString(member.linkedInUrl)}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/app/brands/page.test.tsx
+++ b/src/app/brands/page.test.tsx
@@ -37,6 +37,7 @@ test('renders brand cards with correct links', () => {
   expect(links).toHaveLength(4);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(typeof link.getAttribute('href')).toBe('string');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/app/brands/page.tsx
+++ b/src/app/brands/page.tsx
@@ -4,6 +4,7 @@ import { Button, Col, Container, Image, Placeholder, Ratio, Row } from 'react-bo
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { random } from 'lodash';
 import { ShopProps } from '../../types';
+import { ensureString } from '../../utils';
 
 /**
  * Lists every brand with link to learn more.
@@ -84,7 +85,7 @@ export default function Brands({
                 <Button
                   variant="more"
                   as="a"
-                  href={shop.primaryDomain.url}
+                  href={ensureString(shop.primaryDomain.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/app/contact/page.test.tsx
+++ b/src/app/contact/page.test.tsx
@@ -27,5 +27,6 @@ test('renders brand links', () => {
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(typeof link.getAttribute('href')).toBe('string');
   });
 });

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Col, Container, Image, Placeholder, Ratio, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { ShopProps } from '../../types';
+import { ensureString } from '../../utils';
 
 /**
  * Shows contact information for each brand.
@@ -36,7 +37,7 @@ export default function Contact({
               </Col>
             )) : shops.map(shop => (
               <Col key={shop.id} xs={10} md={5} xl={4}>
-                <a href={shop.primaryDomain.url}>
+                <a href={ensureString(shop.primaryDomain.url)}>
                   <Image src={shop.brand?.logo?.image?.logoUrl} alt={shop.brand?.logo?.image?.altText} width={shop.brand?.logo?.image?.width} height={shop.brand?.logo?.image?.height} fluid />
                 </a>
               </Col>

--- a/src/app/links/page.test.tsx
+++ b/src/app/links/page.test.tsx
@@ -24,6 +24,7 @@ test('renders cards with correct links', () => {
   expect(links).toHaveLength(shops.length);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(typeof link.getAttribute('href')).toBe('string');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/app/news/page.test.tsx
+++ b/src/app/news/page.test.tsx
@@ -22,6 +22,7 @@ test('renders article links', () => {
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', articles[i].onlineStoreUrl);
+    expect(typeof link.getAttribute('href')).toBe('string');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -26,6 +26,7 @@ test('renders brand links with correct hrefs', () => {
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {
     expect(link).toHaveAttribute('href', shops[i].primaryDomain.url);
+    expect(typeof link.getAttribute('href')).toBe('string');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Block } from '@smolpack/react-bootstrap-extensions';
 import { random } from 'lodash';
 import { Articles } from '../components';
 import { HomeProps } from '../types';
+import { ensureString } from '../utils';
 
 /**
  * Home page showing brand highlights and latest news.
@@ -64,7 +65,7 @@ export default function Home({
                   variant="more"
                   size="lg"
                   as="a"
-                  href={shop.primaryDomain.url}
+                  href={ensureString(shop.primaryDomain.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{

--- a/src/app/privacy-policy/page.test.tsx
+++ b/src/app/privacy-policy/page.test.tsx
@@ -17,3 +17,10 @@ test('shows introduction section', () => {
   const section = screen.getByRole('heading', { name: /introduction and scope/i });
   expect(section).toBeInTheDocument();
 });
+
+test('contact link is string', () => {
+  render(<PrivacyPolicy />);
+  const link = screen.getByRole('link', { name: /team@m-k.enterprises/i });
+  expect(link).toHaveAttribute('href', 'mailto:team@m-k.enterprises');
+  expect(typeof link.getAttribute('href')).toBe('string');
+});

--- a/src/components/Articles.test.tsx
+++ b/src/components/Articles.test.tsx
@@ -14,6 +14,7 @@ test('article links have security attributes', () => {
   ];
   render(<Articles loading={false} error={false} articles={articles} />);
   const link = screen.getByRole('button', { name: /read more/i });
+  expect(typeof link.getAttribute('href')).toBe('string');
   expect(link).toHaveAttribute('target', '_blank');
   expect(link).toHaveAttribute('rel', 'noopener noreferrer');
 });

--- a/src/components/Articles.tsx
+++ b/src/components/Articles.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Card, Col, Placeholder, Ratio } from 'react-bootstrap';
 import { random } from 'lodash';
 import { ArticleProps } from '../types';
+import { ensureString } from '../utils';
 
 function Articles(props: ArticleProps) {
   return (
@@ -52,7 +53,7 @@ function Articles(props: ArticleProps) {
               <Button
                 variant="more"
                 as="a"
-                href={article.onlineStoreUrl}
+                href={ensureString(article.onlineStoreUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/components/LinkCard.test.tsx
+++ b/src/components/LinkCard.test.tsx
@@ -20,6 +20,7 @@ test('link has correct attributes', () => {
   render(<LinkCard shop={shop} />);
   const link = screen.getByRole('button', { name: /visit/i });
   expect(link).toHaveAttribute('href', shop.primaryDomain.url);
+  expect(typeof link.getAttribute('href')).toBe('string');
   expect(link).toHaveAttribute('target', '_blank');
   expect(link).toHaveAttribute('rel', 'noopener noreferrer');
 });

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Card, Col, Image } from 'react-bootstrap';
 
 import { Shop } from '../types';
+import { ensureString } from '../utils';
 
 interface LinkCardProps {
   shop: Shop;
@@ -34,7 +35,7 @@ export default function LinkCard(props: LinkCardProps) {
         <Button
           variant="more"
           as="a"
-          href={shop.primaryDomain.url}
+          href={ensureString(shop.primaryDomain.url)}
           target="_blank"
           rel="noopener noreferrer"
           className="stretched-link"

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,10 @@
+import { ensureString } from './utils';
+
+test('returns a string and warns when value is not a string', () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const result = ensureString(123 as unknown as string);
+  expect(typeof result).toBe('string');
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Ensure the given value is a string. Logs a warning when the value is not.
+ *
+ * @param value - Value that may or may not be a string.
+ * @returns The value converted to string when necessary.
+ */
+export function ensureString(value: unknown): string {
+  if (typeof value !== 'string') {
+    // eslint-disable-next-line no-console
+    console.warn('🪲 expected string URL but received:', value);
+  }
+  return typeof value === 'string' ? value : String(value);
+}


### PR DESCRIPTION
## Summary
- add `ensureString` helper
- log non-string URLs and use helper in components
- test URL strings for pages and components

## Testing
- `yarn lint`
- `yarn test`
- `yarn tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68583cf8d31083268a99ee32427f93e6