### PR TITLE
Add useStorefront hook for internal data fetching

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,2 +1,10 @@
 import '@testing-library/jest-dom/extend-expect';
 import 'cross-fetch/polyfill';
+
+const tokenPrefix = 'NEXT_PUBLIC_SHOPIFY_TOKEN_';
+beforeAll(() => {
+  process.env[`${tokenPrefix}BEAR_BELTS`] ||= 'a';
+  process.env[`${tokenPrefix}POCKET_BEARS_APPAREL`] ||= 'b';
+  process.env[`${tokenPrefix}MYTHICAL_MOODS`] ||= 'c';
+  process.env[`${tokenPrefix}AURA_ESSENCE`] ||= 'd';
+});

--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+jest.mock('../../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../../hooks/useStorefront';
 import About from './page';
 
 const urls = [
@@ -8,14 +13,29 @@ const urls = [
   'https://linkedin.com/in/paul-matthews-kennington-201007a6',
 ];
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(<About loading={true} error={false} shops={[]} />);
+  render(<About />);
   const heading = screen.getByRole('heading', { name: /about us/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders team links', () => {
-  render(<About loading={false} error={false} shops={[]} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<About />);
   const links = screen.getAllByRole('button', { name: /linkedin/i });
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {
@@ -27,7 +47,13 @@ test('renders team links', () => {
 });
 
 test('renders about image with alt', () => {
-  render(<About loading={false} error={false} shops={[]} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<About />);
   const image = screen.getByAltText(/Bear Belts launch event/i);
   expect(image).toBeInTheDocument();
 });

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,22 +5,20 @@ import { Block, PullQuote, StatCard } from '@smolpack/react-bootstrap-extensions
 import { intersection, union } from 'lodash';
 import Gravatar from 'react-gravatar';
 
-import { ShopProps } from '../../types';
 import { ensureString } from '../../utils';
+import useStorefront from '../../hooks/useStorefront';
 // @ts-expect-error Image imported as URL
 import about from './about.jpg';
 
 /**
  * About page describing the company and team.
  *
- * @param props - Shop data with loading state.
+ * Fetches shop data to display company information.
+ *
  * @returns JSX for the about route.
  */
-export default function Page({
-  shops = [],
-  loading = false,
-  error = false,
-}: ShopProps) {
+export default function Page() {
+  const { shops, loading, error } = useStorefront();
   const shipsToCountriesMin = intersection(
     ...shops.map(shop => shop.shipsToCountries)
   ).length;

--- a/src/app/brands/page.test.tsx
+++ b/src/app/brands/page.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import Brands from './page';
 import { Shop } from '../../types';
+jest.mock('../../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../../hooks/useStorefront';
+import Brands from './page';
 
 const shops: Shop[] = Array.from({ length: 4 }, (_, i) => ({
   id: String(i + 1),
@@ -25,14 +30,29 @@ const shops: Shop[] = Array.from({ length: 4 }, (_, i) => ({
   },
 }));
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(<Brands loading={true} error={false} shops={[]} />);
+  render(<Brands />);
   const heading = screen.getByRole('heading', { name: /our brands/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders brand cards with correct links', () => {
-  render(<Brands loading={false} error={false} shops={shops} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops,
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<Brands />);
   const links = screen.getAllByRole('button', { name: /learn more/i });
   expect(links).toHaveLength(4);
   links.forEach((link, i) => {

--- a/src/app/brands/page.tsx
+++ b/src/app/brands/page.tsx
@@ -3,20 +3,18 @@ import React from 'react';
 import { Button, Col, Container, Image, Placeholder, Ratio, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { random } from 'lodash';
-import { ShopProps } from '../../types';
 import { ensureString } from '../../utils';
+import useStorefront from '../../hooks/useStorefront';
 
 /**
  * Lists every brand with link to learn more.
  *
- * @param props - Shop data for all brands.
+ * Fetches all shop data for brand listing.
+ *
  * @returns JSX for the brands route.
  */
-export default function Brands({
-  shops = [],
-  loading = false,
-  error = false,
-}: ShopProps) {
+export default function Brands() {
+  const { shops, loading, error } = useStorefront();
   return (
     <>
       <Block className="text-bg-primary">

--- a/src/app/contact/page.test.tsx
+++ b/src/app/contact/page.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import Contact from './page';
 import { Shop } from '../../types';
+jest.mock('../../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../../hooks/useStorefront';
+import Contact from './page';
 
 const shops: Shop[] = Array.from({ length: 2 }, (_, i) => ({
   id: String(i + 1),
@@ -15,14 +20,29 @@ const shops: Shop[] = Array.from({ length: 2 }, (_, i) => ({
   },
 }));
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(<Contact loading={true} error={false} shops={[]} />);
+  render(<Contact />);
   const heading = screen.getByRole('heading', { name: /need support\?/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders brand links', () => {
-  render(<Contact loading={false} error={false} shops={shops} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops,
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<Contact />);
   const links = screen.getAllByRole('link');
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,20 +2,17 @@
 import React from 'react';
 import { Col, Container, Image, Placeholder, Ratio, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
-import { ShopProps } from '../../types';
 import { ensureString } from '../../utils';
+import useStorefront from '../../hooks/useStorefront';
 
 /**
  * Shows contact information for each brand.
+ * Fetches shop data to display contact information.
  *
- * @param props - Shop data with loading state.
  * @returns JSX for the contact route.
  */
-export default function Contact({
-  shops = [],
-  loading = false,
-  error = false,
-}: ShopProps) {
+export default function Contact() {
+  const { shops, loading, error } = useStorefront();
   return (
     <>
       <Block className="text-bg-primary">

--- a/src/app/links/page.test.tsx
+++ b/src/app/links/page.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import Links from './page';
 import { Shop } from '../../types';
+jest.mock('../../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../../hooks/useStorefront';
+import Links from './page';
 
 const shops: Shop[] = Array.from({ length: 3 }, (_, i) => ({
   id: String(i + 1),
@@ -12,14 +17,35 @@ const shops: Shop[] = Array.from({ length: 3 }, (_, i) => ({
   brand: { slogan: `Tagline ${i + 1}`, colors: { primary: [{}] } }
 }));
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: false,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(<Links loading={false} error={false} shops={shops} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops,
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<Links />);
   const heading = screen.getByRole('heading', { name: /useful links/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders cards with correct links', () => {
-  render(<Links loading={false} error={false} shops={shops} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops,
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<Links />);
   const links = screen.getAllByRole('button', { name: /visit/i });
   expect(links).toHaveLength(shops.length);
   links.forEach((link, i) => {

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -3,19 +3,19 @@ import React from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 
-import { ShopProps } from '../../types';
 import { LinkCard } from '../../components';
+import useStorefront from '../../hooks/useStorefront';
 
-interface LinksProps extends ShopProps {}
 
 /**
  * External links page.
+ * Fetches shop data for quick access to brand links.
  *
- * @param props - Shop data with loading state.
  * @returns React element containing corporate links.
  */
 
-export default function Links({ shops = [] }: LinksProps) {
+export default function Links() {
+  const { shops } = useStorefront();
   const items = shops;
 
   return (

--- a/src/app/news/page.test.tsx
+++ b/src/app/news/page.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+jest.mock('../../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../../hooks/useStorefront';
 import News from './page';
 
 const articles = Array.from({ length: 2 }, (_, i) => ({
@@ -10,14 +15,29 @@ const articles = Array.from({ length: 2 }, (_, i) => ({
   publishedAt: '2022-01-01T00:00:00Z',
 }));
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(<News loading={true} error={false} articles={[]} />);
+  render(<News />);
   const heading = screen.getByRole('heading', { name: /latest news/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders article links', () => {
-  render(<News loading={false} error={false} articles={articles} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles,
+    loading: false,
+    error: false,
+  });
+  render(<News />);
   const links = screen.getAllByRole('button', { name: /read more/i });
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -3,19 +3,17 @@ import React from 'react';
 import { Container, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { Articles } from '../../components';
-import { ArticleProps } from '../../types';
+import useStorefront from '../../hooks/useStorefront';
 
 /**
  * News route listing recent company articles.
  *
- * @param props - Article data with loading state.
+ * Fetches article data for the news listing.
+ *
  * @returns JSX for the news route.
  */
-export default function News({
-  loading = false,
-  error = false,
-  articles = [],
-}: ArticleProps) {
+export default function News() {
+  const { articles, loading, error } = useStorefront();
   return (
     <>
       <Block className="text-bg-primary">

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+jest.mock('../hooks/useStorefront', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import useStorefront from '../hooks/useStorefront';
 import Home from './page';
 import { Shop } from '../types';
 
@@ -12,16 +17,29 @@ const shops: Shop[] = Array.from({ length: 2 }, (_, i) => ({
   brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } },
 }));
 
+beforeEach(() => {
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+});
+
 test('renders heading', () => {
-  render(
-    <Home loading={true} error={false} shops={[]} articles={[]} />
-  );
+  render(<Home />);
   const heading = screen.getByRole('heading', { name: /latest news/i });
   expect(heading).toBeInTheDocument();
 });
 
 test('renders brand links with correct hrefs', () => {
-  render(<Home loading={false} error={false} shops={shops} articles={[]} />);
+  (useStorefront as jest.Mock).mockReturnValue({
+    shops,
+    articles: [],
+    loading: false,
+    error: false,
+  });
+  render(<Home />);
   const links = screen.getAllByRole('button', { name: /learn more/i });
   expect(links).toHaveLength(2);
   links.forEach((link, i) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,21 +4,18 @@ import { Button, Carousel, Container, Placeholder, Row } from 'react-bootstrap';
 import { Block } from '@smolpack/react-bootstrap-extensions';
 import { random } from 'lodash';
 import { Articles } from '../components';
-import { HomeProps } from '../types';
+import useStorefront from '../hooks/useStorefront';
 import { ensureString } from '../utils';
 
 /**
  * Home page showing brand highlights and latest news.
  *
- * @param props - Shop and article data with loading states.
+ * Fetches shop and article data using configured clients.
+ *
  * @returns JSX for the home route.
  */
-export default function Home({
-  shops = [],
-  articles = [],
-  loading = false,
-  error = false,
-}: HomeProps) {
+export default function Home() {
+  const { shops, articles, loading, error } = useStorefront();
   return (
     <>
       <Carousel>

--- a/src/components/Articles.tsx
+++ b/src/components/Articles.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { Button, Card, Col, Placeholder, Ratio } from 'react-bootstrap';
 import { random } from 'lodash';
-import { ArticleProps } from '../types';
+import { Article } from '../types';
 import { ensureString } from '../utils';
 
-function Articles(props: ArticleProps) {
+interface ArticlesProps {
+  loading: boolean;
+  error: boolean;
+  articles: Article[];
+}
+
+/**
+ * Displays a list of articles with loading placeholders.
+ *
+ * @param props - Article data and status flags.
+ * @returns Grid of article cards.
+ */
+function Articles(props: ArticlesProps) {
   return (
     <>
       {props.loading || props.error ? Array.from({ length: 6 }).map((_, index) => (

--- a/src/hooks/useStorefront.test.tsx
+++ b/src/hooks/useStorefront.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+var mockQuery: jest.Mock;
+jest.mock('../clients', () => {
+  mockQuery = jest.fn();
+  return {
+    clients: {
+      bearBelts: { query: mockQuery },
+      pocketBearsApparel: { query: mockQuery },
+      mythicalMoods: { query: mockQuery },
+      auraEssence: { query: mockQuery },
+    },
+  };
+});
+
+import useStorefront from './useStorefront';
+
+const mockResponse = {
+  data: {
+    shop: { id: '1', name: 'x', shipsToCountries: [], primaryDomain: { url: 'u' } },
+    articles: { nodes: [{ id: 'a', title: 't', publishedAt: '', onlineStoreUrl: '' }] },
+  },
+};
+
+describe('useStorefront', () => {
+  it('loads shops and articles', async () => {
+    mockQuery.mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useStorefront());
+    await waitFor(() => !result.current.loading);
+    expect(mockQuery).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useStorefront.ts
+++ b/src/hooks/useStorefront.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { loader } from 'graphql.macro';
+import { ApolloQueryResult } from '@apollo/client';
+import { clients } from '../clients';
+import { Article, Shop } from '../types';
+
+const STOREFRONT_QUERY = loader('../storefront.gql');
+
+export interface StorefrontState {
+  shops: Shop[];
+  articles: Article[];
+  loading: boolean;
+  error: boolean;
+}
+
+/**
+ * Fetches shops and articles using the configured Shopify clients.
+ *
+ * @returns Data and status flags.
+ */
+export default function useStorefront(): StorefrontState {
+  const [state, setState] = useState<StorefrontState>({
+    shops: [],
+    articles: [],
+    loading: true,
+    error: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const results: ApolloQueryResult<any>[] = await Promise.all(
+          Object.values(clients).map(client => client.query({
+            query: STOREFRONT_QUERY,
+            fetchPolicy: 'no-cache',
+          }))
+        );
+        if (!active) return;
+        setState({
+          shops: results.map(r => r.data.shop as Shop),
+          articles: results.flatMap(r => r.data.articles.nodes as Article[]),
+          loading: false,
+          error: false,
+        });
+      } catch {
+        if (active) {
+          setState(prev => ({ ...prev, loading: false, error: true }));
+        }
+      }
+    }
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,17 +42,3 @@ export interface Image {
   height?: number;
 }
 
-export interface QueryProps {
-  loading: boolean;
-  error: boolean;
-}
-
-export interface ShopProps extends QueryProps {
-  shops: Shop[];
-}
-
-export interface ArticleProps extends QueryProps {
-  articles: Article[];
-}
-
-export interface HomeProps extends ShopProps, ArticleProps {}


### PR DESCRIPTION
## Summary
- fetch Shopify storefront data in pages via new `useStorefront` hook
- update tests to mock the hook and clients
- keep tests running by providing default env vars

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68586eff6be08326b509a797fbed4ef0