### PR TITLE
Fix Sass deprecation for Bootstrap mix

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,11 @@
 @import "pantone-css/scss/pantone";
 @import "@smolpack/bootstrap-extensions/scss/functions";
 
+// Patch Bootstrap's opaque() to avoid Sass warning about unitless percentages
+@function opaque($background, $foreground) {
+  @return mix(rgba($foreground, 1), $background, opacity($foreground) * 100%);
+}
+
 $enable-rounded: false;
 $enable-negative-margins: true;
 


### PR DESCRIPTION
## Summary
- patch `opaque()` function to add unit percentage

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685d810c7bbc8326aa0cfa7eafd0b589