### PR TITLE
Remove unused unsplash-js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react-gravatar": "^2.6.3",
     "sass": "^1.56.1",
     "typescript": "^4.4.2",
-    "unsplash-js": "^7.0.15",
     "web-vitals": "^2.1.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,11 +1248,6 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/content-type@^1.1.3":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@types/content-type/-/content-type-1.1.5.tgz#aa02dca40864749a9e2bf0161a6216da57e3ede5"
-  integrity sha512-dgMN+syt1xb7Hk8LU6AODOfPlvz5z1CbXpPuJE5ZrX9STfBOIXF09pEB8N7a97WT9dbngt3ksDCm6GW6yMrxfQ==
-
 "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
@@ -2253,11 +2248,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
-content-type@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -6005,14 +5995,6 @@ unrs-resolver@^1.6.2, unrs-resolver@^1.7.11:
     "@unrs/resolver-binding-win32-arm64-msvc" "1.9.0"
     "@unrs/resolver-binding-win32-ia32-msvc" "1.9.0"
     "@unrs/resolver-binding-win32-x64-msvc" "1.9.0"
-
-unsplash-js@^7.0.15:
-  version "7.0.15"
-  resolved "https://registry.yarnpkg.com/unsplash-js/-/unsplash-js-7.0.15.tgz#9eee0ce552e2c2ee70fd30a767c59b159e004753"
-  integrity sha512-WGqKp9wl2m2tAUPyw2eMZs/KICR+A52tCaRapzVXWxkA4pjHqsaGwiJXTEW7hBy4Pu0QmP6KxTt2jST3tluawA==
-  dependencies:
-    "@types/content-type" "^1.1.3"
-    content-type "^1.0.4"
 
 update-browserslist-db@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
## Summary
- drop `unsplash-js` from dependencies
- regenerate lockfile

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686183af16848326a07de7e7f691af26