### PR TITLE
Fix Apollo client options type

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, ApolloClientOptions, InMemoryCache } from '@apollo/client';
 
-interface ClientOptions extends Partial<ApolloClientOptions<{}>> {
+interface ClientOptions extends Partial<ApolloClientOptions<unknown>> {
   shopifyStorefrontAccessToken: string
 }
 


### PR DESCRIPTION
## Summary
- relax generics on `ApolloClientOptions`

## Testing
- `npx tsc --noEmit`
- `yarn lint`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68618fa954308326921b7b75dcf47985