### PR TITLE
Add performance reporting

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import { Block } from '@smolpack/react-bootstrap-extensions';
 // @ts-expect-error Image imported as URL
 import logo from '../logo.svg';
 
+import usePerformanceReporting from '../hooks/usePerformanceReporting';
+
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../index.scss';
 import '../App.scss';
@@ -24,6 +26,7 @@ interface LayoutProps {
  * @returns Page wrapper element.
  */
 export default function RootLayout({ children }: LayoutProps) {
+  usePerformanceReporting();
   const now = new Date();
 
   return (

--- a/src/hooks/usePerformanceReporting.test.tsx
+++ b/src/hooks/usePerformanceReporting.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import usePerformanceReporting from './usePerformanceReporting';
+import reportWebVitals from '../reportWebVitals';
+
+jest.mock('../reportWebVitals');
+
+describe('usePerformanceReporting', () => {
+  function TestComponent() {
+    usePerformanceReporting();
+    return null;
+  }
+
+  it('calls reportWebVitals', () => {
+    render(<TestComponent />);
+    expect(reportWebVitals).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePerformanceReporting.ts
+++ b/src/hooks/usePerformanceReporting.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import reportWebVitals from '../reportWebVitals';
+
+/**
+ * Registers web-vitals reporting to the console.
+ */
+export default function usePerformanceReporting(): void {
+  useEffect(() => {
+    reportWebVitals(metric => {
+      // eslint-disable-next-line no-console
+      console.log(metric);
+    });
+  }, []);
+}

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,4 +1,9 @@
 import { ReportHandler } from 'web-vitals';
+/**
+ * Measures and forwards Web Vitals metrics to the given handler.
+ *
+ * @param onPerfEntry - Callback invoked with each metric.
+ */
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {


### PR DESCRIPTION
## Summary
- log web-vitals via `usePerformanceReporting` hook
- call the hook from the root layout
- document metrics reporter
- test the new hook

## Testing
- `yarn lint`
- `npx tsc --noEmit`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68626c85da248326a8fbaa59468f46ab