### PR TITLE
⚡ Optimize redundant array mapping in About shipping stats

### DIFF
--- a/src/routes/About.bench.test.tsx
+++ b/src/routes/About.bench.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import About from './About';
+import { Shop } from '../App';
+
+describe('About performance benchmark', () => {
+  test('counts access to shipsToCountries on initial render', () => {
+    const accessSpy = jest.fn();
+    const shops: Shop[] = [
+      {
+        id: '1',
+        name: 'Shop 1',
+        get shipsToCountries() {
+          accessSpy();
+          return ['US', 'CA'];
+        },
+        primaryDomain: { url: 'https://shop1.com' },
+        brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } },
+      } as any as Shop,
+    ];
+
+    render(<About loading={false} error={false} shops={shops} />);
+
+    // After optimization, there is one useMemo hook calling .map(shop => shop.shipsToCountries)
+    // and two other useMemo hooks using the result.
+    // So accessSpy should be called exactly once per shop.
+    expect(accessSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -21,13 +21,17 @@ function About(props: ShopProps) {
     description: 'Learn about the M-K Enterprises story, mission, and leadership team.',
   });
 
-  const shipsToCountriesMin = useMemo(
-    () => intersection(...props.shops.map(shop => shop.shipsToCountries)).length,
+  const shipsToCountries = useMemo(
+    () => props.shops.map(shop => shop.shipsToCountries),
     [props.shops]
   );
+  const shipsToCountriesMin = useMemo(
+    () => intersection(...shipsToCountries).length,
+    [shipsToCountries]
+  );
   const shipsToCountriesMax = useMemo(
-    () => union(...props.shops.map(shop => shop.shipsToCountries)).length,
-    [props.shops]
+    () => union(...shipsToCountries).length,
+    [shipsToCountries]
   );
 
   const team = [


### PR DESCRIPTION
💡 **What:** Extracted the redundant `props.shops.map(shop => shop.shipsToCountries)` call in the `About` component into its own `useMemo` hook.
🎯 **Why:** Previously, the `About` component performed the same array mapping twice—once for the `intersection` (min countries) calculation and once for the `union` (max countries) calculation. This resulted in unnecessary CPU cycles and memory allocations on every render where `props.shops` changed.
📊 **Measured Improvement:** Established a baseline and verified the improvement using a new benchmark test (`src/routes/About.bench.test.tsx`). The benchmark uses a getter spy to count accesses to the `shipsToCountries` property.
- **Baseline:** 2 accesses per shop (one for each `map` call).
- **Optimized:** 1 access per shop.
This confirms a 50% reduction in the redundant mapping work within the `About` component's data preparation phase.

---
*PR created automatically by Jules for task [13139268133678231831](https://jules.google.com/task/13139268133678231831) started by @SmolSoftBoi*