### PR TITLE
⚡ optimize redundant array mapping in About.tsx

### DIFF
--- a/src/routes/About.bench.test.tsx
+++ b/src/routes/About.bench.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import About from './About';
+import { Shop } from '../App';
+
+test('About only maps shipsToCountries once', () => {
+  const countAccess = jest.fn();
+  const shops = [
+    {
+      id: '1',
+      name: 'Shop 1',
+      get shipsToCountries() {
+        countAccess();
+        return ['US', 'CA'];
+      },
+    },
+    {
+      id: '2',
+      name: 'Shop 2',
+      get shipsToCountries() {
+        countAccess();
+        return ['US', 'GB'];
+      },
+    }
+  ] as unknown as Shop[];
+
+  render(<About loading={false} error={false} shops={shops} />);
+
+  // In the current implementation, it maps twice (once for min, once for max)
+  // Each map iterates over all shops. So 2 shops * 2 maps = 4 accesses.
+  // We want to optimize it to 2 accesses.
+  expect(countAccess).toHaveBeenCalledTimes(2);
+});

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -21,13 +21,18 @@ function About(props: ShopProps) {
     description: 'Learn about the M-K Enterprises story, mission, and leadership team.',
   });
 
-  const shipsToCountriesMin = useMemo(
-    () => intersection(...props.shops.map(shop => shop.shipsToCountries)).length,
+  const shipsToCountries = useMemo(
+    () => props.shops.map((shop) => shop.shipsToCountries),
     [props.shops]
   );
+
+  const shipsToCountriesMin = useMemo(
+    () => intersection(...shipsToCountries).length,
+    [shipsToCountries]
+  );
   const shipsToCountriesMax = useMemo(
-    () => union(...props.shops.map(shop => shop.shipsToCountries)).length,
-    [props.shops]
+    () => union(...shipsToCountries).length,
+    [shipsToCountries]
   );
 
   const team = [


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Refactored `src/routes/About.tsx` to map `props.shops` once inside a `useMemo` hook.
- Reused the resulting `shipsToCountries` array for both intersection and union operations.
- Added `src/routes/About.bench.test.tsx` to verify the reduction in property access.

🎯 **Why:** The performance problem it solves
The previous implementation called `.map()` twice on `props.shops`, once for the `shipsToCountriesMin` calculation and once for `shipsToCountriesMax`. This resulted in redundant iterations over the `shops` array and redundant property accesses.

📊 **Measured Improvement:**
- Verified using `src/routes/About.bench.test.tsx` which uses a getter to count accesses to `shop.shipsToCountries`.
- Baseline: 4 accesses for 2 shops (2 maps * 2 shops).
- After Optimization: 2 accesses for 2 shops (1 map * 2 shops).
- Result: **50% reduction** in mapping iterations and property access for these specific calculations.

---
*PR created automatically by Jules for task [3895952594764845254](https://jules.google.com/task/3895952594764845254) started by @SmolSoftBoi*