### PR TITLE
⚡ Optimize redundant array mapping in About component

### DIFF
--- a/src/routes/About.bench.test.tsx
+++ b/src/routes/About.bench.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import About from './About';
+import { Shop } from '../App';
+
+test('About component mapping is not redundant', () => {
+  let accessCount = 0;
+  const shops: Shop[] = [
+    {
+      id: '1',
+      name: 'Shop 1',
+      get shipsToCountries() {
+        accessCount++;
+        return ['US', 'CA'];
+      },
+      primaryDomain: { url: 'https://shop1.com' },
+      brand: { colors: { primary: [{ background: '#fff', foreground: '#000' }] } },
+    } as any,
+  ];
+
+  render(<About loading={false} error={false} shops={shops} />);
+
+  // After optimization, it should be mapped only once.
+  expect(accessCount).toBe(1);
+});

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -21,14 +21,13 @@ function About(props: ShopProps) {
     description: 'Learn about the M-K Enterprises story, mission, and leadership team.',
   });
 
-  const shipsToCountriesMin = useMemo(
-    () => intersection(...props.shops.map(shop => shop.shipsToCountries)).length,
-    [props.shops]
-  );
-  const shipsToCountriesMax = useMemo(
-    () => union(...props.shops.map(shop => shop.shipsToCountries)).length,
-    [props.shops]
-  );
+  const { shipsToCountriesMin, shipsToCountriesMax } = useMemo(() => {
+    const countriesList = props.shops.map((shop) => shop.shipsToCountries);
+    return {
+      shipsToCountriesMin: intersection(...countriesList).length,
+      shipsToCountriesMax: union(...countriesList).length,
+    };
+  }, [props.shops]);
 
   const team = [
     {


### PR DESCRIPTION
💡 **What:** The optimization implemented
Consolidated two separate `useMemo` hooks in `src/routes/About.tsx` into a single hook that performs the `props.shops.map` operation once and calculates both `shipsToCountriesMin` (intersection) and `shipsToCountriesMax` (union).

🎯 **Why:** The performance problem it solves
The previous implementation performed the same array mapping twice, creating two identical intermediate arrays and iterating over `props.shops` twice for every change to the shops prop.

📊 **Measured Improvement:**
Using a targeted benchmark test `src/routes/About.bench.test.tsx`, I verified that the access count for the `shipsToCountries` property on the shop objects was reduced from **2 to 1** per render cycle. This confirms that the redundant mapping has been eliminated.


---
*PR created automatically by Jules for task [3662676545308454954](https://jules.google.com/task/3662676545308454954) started by @SmolSoftBoi*